### PR TITLE
feat: added /movies/trending endpoint using TMDB API

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+.env
+.venv
+backend/app/__pycache__/

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,5 @@ SQLAlchemy==2.0.41
 typing_extensions==4.14.1
 Werkzeug==3.1.3
 Flask-SocketIO==5.3.6
+requests==2.31.0
+python-dotenv==1.0.1


### PR DESCRIPTION
### What I did
- integrated TMDB API to fetch trending movies (daily)
- created `/movies/trending` endpoint in Flask
- filters movie data to include: title, overview, poster
- ensured response is in clean JSON format

### How to test
- run Flask backend (`python run.py`)
- hit `GET /movies/trending` locally using:


```
  curl http://localhost:5000/movies/trending
```


- should return a list of movies from TMDB (title, overview, poster)


### Notes
- used requests and python-dotenv
- TMDB API key is stored in .env (not pushed to repo)
- endpoint ready to be connected with frontend when needed